### PR TITLE
chore: 処理の実行後にコンポーネントを削除するように

### DIFF
--- a/Packages/com.hhotatea.avatar-pose-library/Editor/Plugin/AutoThumbnailPlugin.cs
+++ b/Packages/com.hhotatea.avatar-pose-library/Editor/Plugin/AutoThumbnailPlugin.cs
@@ -7,6 +7,7 @@ using com.hhotatea.avatar_pose_library.model;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
+using Object = UnityEngine.Object;
 
 [assembly: ExportsPlugin(typeof(AutoThumbnailPlugin))]
 namespace com.hhotatea.avatar_pose_library.editor
@@ -17,6 +18,7 @@ namespace com.hhotatea.avatar_pose_library.editor
         {
             InPhase(BuildPhase.Optimizing)
                 .AfterPlugin("nadena.dev.modular-avatar")
+                .BeforePlugin("com.anatawa12.avatar-optimizer")
                 .Run("AvatarPose: Replace thumbnail...", ctx =>
                 {
                     var settings = ctx.AvatarRootObject.GetComponentsInChildren<AvatarPoseLibrary>();
@@ -38,6 +40,8 @@ namespace com.hhotatea.avatar_pose_library.editor
                                 }
                             }
                         }
+
+                        Object.DestroyImmediate(setting);
                     }
                 });
         }


### PR DESCRIPTION
[Avatar Optimizer] というツールを作ってる anatawa12 です。

Avatar Optimizer にある [Trace and Optimize] というコンポーネントは、アバターにあるコンポーネントを走査する都合上、未知のコンポーネントが残っている際に警告を発生させる仕様とさせていただいています。

Avatar Pose Library と Avatar Optimizer を併用しているユーザより、警告が出るという報告を受けたため、Avatar Pose Library の Avatar Optimizer の前に実行するようにし、コンポーネントを削除するように変更した pull request を送りました。

[Avatar Optimizer]: https://an12.net/aao
[Trace and Optimize]: https://vpm.anatawa12.com/avatar-optimizer/ja/docs/reference/trace-and-optimize/