### PR TITLE
Mirror時にアニメーションが途中から再生される不具合修正

### DIFF
--- a/Packages/com.hhotatea.avatar-pose-library/Editor/Logic/AnimationLayerBuilder.cs
+++ b/Packages/com.hhotatea.avatar-pose-library/Editor/Logic/AnimationLayerBuilder.cs
@@ -61,6 +61,11 @@ namespace com.hhotatea.avatar_pose_library.logic {
             }
             paramReset.parameters.Add (new VRC_AvatarParameterDriver.Parameter {
                 type = VRC_AvatarParameterDriver.ChangeType.Set,
+                name = $"{ConstVariables.MirrorCycleOffsetParamPrefix}_{poseLibrary.Guid}",
+                value = 0,
+            });
+            paramReset.parameters.Add (new VRC_AvatarParameterDriver.Parameter {
+                type = VRC_AvatarParameterDriver.ChangeType.Set,
                 name = $"{ConstVariables.PoseSpaceParamPrefix}_{poseLibrary.Guid}",
                 value = 0,
             });
@@ -124,7 +129,8 @@ namespace com.hhotatea.avatar_pose_library.logic {
             Finger,
             Face,
             Action,
-            Space
+            Space,
+            Mirror
         }
 
         public AnimatorControllerLayer ActiveTrackingLayer(TrackingType type, string param, string guid)
@@ -271,6 +277,24 @@ namespace com.hhotatea.avatar_pose_library.logic {
                     var spaceExit = offConState.AddStateMachineBehaviour<VRCAnimatorTemporaryPoseSpace>();
                     spaceExit.enterPoseSpace = false;
 
+                    break;
+
+                case TrackingType.Mirror:
+                    var mirrorOffDriver = offConState.AddSafeParameterDriver();
+                    mirrorOffDriver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+                    {
+                        type = VRC_AvatarParameterDriver.ChangeType.Set,
+                        name = $"{ConstVariables.MirrorCycleOffsetParamPrefix}_{guid}",
+                        value = 0f,
+                    });
+
+                    var mirrorOnDriver = onConState.AddSafeParameterDriver();
+                    mirrorOnDriver.parameters.Add(new VRC_AvatarParameterDriver.Parameter
+                    {
+                        type = VRC_AvatarParameterDriver.ChangeType.Set,
+                        name = $"{ConstVariables.MirrorCycleOffsetParamPrefix}_{guid}",
+                        value = 0.5f,
+                    });
                     break;
             }
 
@@ -586,6 +610,12 @@ namespace com.hhotatea.avatar_pose_library.logic {
                 poseState.speed = pose.tracking.motionSpeed * 2f;
                 poseState.speedParameterActive = true;
                 poseState.speedParameter = $"{ConstVariables.SpeedParamPrefix}_{guid}";
+                if(pose.tracking.loop)
+                {
+                    // Unityの不具合対策でOffsetを入れる
+                    poseState.cycleOffsetParameterActive = true;
+                    poseState.cycleOffsetParameter = $"{ConstVariables.MirrorCycleOffsetParamPrefix}_{guid}";
+                }
             }
 
             var inTransition = flags.Select((flag, i) => new AnimatorCondition
@@ -689,6 +719,12 @@ namespace com.hhotatea.avatar_pose_library.logic {
                 poseState.speed = pose.tracking.motionSpeed * 2f;
                 poseState.speedParameterActive = true;
                 poseState.speedParameter = $"{ConstVariables.SpeedParamPrefix}_{guid}";
+                if(pose.tracking.loop)
+                {
+                    // Unityの不具合対策でOffsetを入れる
+                    poseState.cycleOffsetParameterActive = true;
+                    poseState.cycleOffsetParameter = $"{ConstVariables.MirrorCycleOffsetParamPrefix}_{guid}";
+                }
             }
 
             // 侵入経路

--- a/Packages/com.hhotatea.avatar-pose-library/Editor/Logic/AnimatorBuilder.cs
+++ b/Packages/com.hhotatea.avatar-pose-library/Editor/Logic/AnimatorBuilder.cs
@@ -240,6 +240,7 @@ namespace com.hhotatea.avatar_pose_library.logic {
             result.AddLayer (builder.ConstantTrackingLayer (TrackingType.Foot, $"{ConstVariables.FootParamPrefix}_{poseLibrary.Guid}", poseLibrary.Guid));
             result.AddLayer (builder.ConstantTrackingLayer (TrackingType.Finger, $"{ConstVariables.FingerParamPrefix}_{poseLibrary.Guid}", poseLibrary.Guid));
             result.AddLayer (builder.ActiveTrackingLayer (TrackingType.Face, $"{ConstVariables.FaceParamPrefix}_{poseLibrary.Guid}", poseLibrary.Guid));
+            result.AddLayer (builder.ConstantTrackingLayer (TrackingType.Mirror, $"{ConstVariables.MirrorParamPrefix}_{poseLibrary.Guid}", poseLibrary.Guid));
             result.AddLayer (builder.ResetLayer($"{ConstVariables.ResetParamPrefix}_{poseLibrary.Guid}", poseLibrary));
             
             if(poseLibrary.EnableAudioMode)
@@ -290,6 +291,13 @@ namespace com.hhotatea.avatar_pose_library.logic {
                 defaultBool = false,
             };
             result.AddParameter (mirrorParam);
+
+            var mirrorCycleOffsetParam = new AnimatorControllerParameter {
+                name = $"{ConstVariables.MirrorCycleOffsetParamPrefix}_{poseLibrary.Guid}",
+                type = AnimatorControllerParameterType.Float,
+                defaultFloat = 0f,
+            };
+            result.AddParameter (mirrorCycleOffsetParam);
 
             foreach (var param in poseLibrary.Parameters) {
                 // パラメーター追加

--- a/Packages/com.hhotatea.avatar-pose-library/Editor/Logic/ParameterBuilder.cs
+++ b/Packages/com.hhotatea.avatar-pose-library/Editor/Logic/ParameterBuilder.cs
@@ -141,6 +141,14 @@ namespace com.hhotatea.avatar_pose_library.logic
                     defaultValue = 0,
                     saved = true,
                 });
+                mResult.parameters.Add(new ParameterConfig
+                {
+                    nameOrPrefix = $"{ConstVariables.MirrorCycleOffsetParamPrefix}_{poseLibrary.Guid}",
+                    syncType = ParameterSyncType.Float,
+                    localOnly = true,
+                    defaultValue = 0,
+                    saved = false,
+                });
             }
 
             if (poseLibrary.enablePoseSpace)

--- a/Packages/com.hhotatea.avatar-pose-library/Runtime/Model/ConstVariables.cs
+++ b/Packages/com.hhotatea.avatar-pose-library/Runtime/Model/ConstVariables.cs
@@ -21,6 +21,7 @@ namespace com.hhotatea.avatar_pose_library.model
         public const string SpeedParamPrefix = "AnimPoseSpeed";
         public const string ResetParamPrefix = "AnimPoseReset";
         public const string MirrorParamPrefix = "AnimPoseMirror";
+        public const string MirrorCycleOffsetParamPrefix = "AnimPoseMirrorCycleOffset";
         public const string FlagParamPrefix = "AnimPoseFlag";
         public const string AudioParamPrefix = "AnimPoseAudio";
         public const string PoseSpaceParamPrefix = "AnimPoseSpace";

--- a/Packages/com.hhotatea.avatar-pose-library/package.json
+++ b/Packages/com.hhotatea.avatar-pose-library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.hhotatea.avatar-pose-library",
   "displayName": "AvatarPoseLibrary",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "VRChat\u306e\u30a8\u30e2\u30fc\u30c8\u30a2\u30cb\u30e1\u30fc\u30b7\u30e7\u30f3\u3092\u81ea\u52d5\u8a2d\u5b9a\u3059\u308b\u30c4\u30fc\u30eb\u7fa4\u3002",
   "gitDependencies": {},
   "vpmDependencies": {


### PR DESCRIPTION
https://issuetracker.unity3d.com/issues/animation-mirror-option-adds-0-dot-5-cycle-offset-when-root-motion-is-enabled
の件